### PR TITLE
feat: add xclip to add clipboard support for console applications on x11

### DIFF
--- a/applications/editors.nix
+++ b/applications/editors.nix
@@ -1,10 +1,15 @@
 { pkgs, ... }: {
+  # GH-14: Add clipboard support
+  environment.systemPackages = [
+    pkgs.xclip
+  ];
   programs = {
     nano.enable = false;
     neovim = {
       enable = true;
       defaultEditor = true;
       vimAlias = true;
+      viAlias = true;
     };
   };
 }


### PR DESCRIPTION
Motivation:
This PR is to add clipboard support for console applications on x11 system.

Changes:
- Add `xclip` to system packages

Test:
`nixos-rebuild switch` success